### PR TITLE
Automatically open folds when entering file

### DIFF
--- a/plugin/side-search.vim
+++ b/plugin/side-search.vim
@@ -117,6 +117,7 @@ function! s:open_cursor_location(exec_after) abort
       let file_path = getline(file_pos)
       call s:open_largest(file_path)
       execute 'normal! ' . lnum . expand('Gzz')
+      execute 'normal! zv'
       if a:exec_after != ''
         execute a:exec_after
       endif


### PR DESCRIPTION
> zv        View cursor line: Open just enough folds to make the line in
>       which the cursor is located not folded.
