### PR TITLE
if available, use FindRootDirectory() (airblade/vim-rooter) instead of s:guessProjectRoot()

### DIFF
--- a/plugin/side-search.vim
+++ b/plugin/side-search.vim
@@ -157,8 +157,12 @@ endfunction
 
 function! s:guessProjectRoot()
   if exists("*FindRootDirectory")
-    return FindRootDirectory()
+    let l:root = FindRootDirectory()
+    if l:root != ''
+      return l:root
+    endif
   endif
+
   let l:cwd = getcwd()
   let l:maxdistance = len(split(l:cwd, '/')) - 2
   let l:searchdir = ''

--- a/plugin/side-search.vim
+++ b/plugin/side-search.vim
@@ -156,6 +156,9 @@ function! SideSearchWinnr()
 endfunction
 
 function! s:guessProjectRoot()
+  if exists("*FindRootDirectory")
+    return FindRootDirectory()
+  endif
   let l:cwd = getcwd()
   let l:maxdistance = len(split(l:cwd, '/')) - 2
   let l:searchdir = ''


### PR DESCRIPTION
If FindRootDirectory() exists, the paths in vim-side-search would become absolute, and the project root directory would be consistent with other users of FindRootDirectory() / `airblade/vim-rooter`

vim-rooter is often used to find project root directory and having another custom implementation in vim-side-search results in inconsistent project root directory resolution and other various issues

an issue I had was due to my configuration:
```
" set current working directory to that of the file
set autochdir
autocmd BufEnter * lcd %:p:h
let g:rooter_manual_only = 1
```
After the first navigation to a file in vim-side-search, the second one failed, because vim-side-search used relative directories