### PR TITLE
enable specifying a root-relative subdirectory to be searched in

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,18 @@ function! FindRootDirectory()
   return getcwd()
 endfunction
 ```
+
+> How to search in a root-relative subdirectory?
+
+Add this to your configuration:
+```vim
+function! SideSearchRestrictedAndRelative(query, ...) abort
+  let l:subdir = get(a:, 1, '.')
+  call SideSearch(shellescape(a:query, 1), '/' . l:subdir)
+endfunction
+command! -complete=file -nargs=+ SideSearchRestrictedAndRelative call SideSearchRestrictedAndRelative(<f-args>)
+```
+
+To search in root-relative directory, do: `:SideSearchRestrictedAndRelative some\ query some/root-relative/directory`.
+
+Having the command abbreviation `cabbrev SS SideSearchRestrictedAndRelative` in config would make this shorter: `:SS some\ query some/root-relative/directory`

--- a/README.md
+++ b/README.md
@@ -111,6 +111,6 @@ endfunction
 command! -complete=file -nargs=+ SideSearchRestrictedAndRelative call SideSearchRestrictedAndRelative(<f-args>)
 ```
 
-To search in root-relative directory, do: `:SideSearchRestrictedAndRelative some\ query some/root-relative/directory`.
+To search in a root-relative directory, do: `:SideSearchRestrictedAndRelative some\ query some/root-relative/directory`.
 
-Having the command abbreviation `cabbrev SS SideSearchRestrictedAndRelative` in config would make this shorter: `:SS some\ query some/root-relative/directory`
+Having the command abbreviation `cabbrev SS SideSearchRestrictedAndRelative` in config would make this shorter: `:SS some\ query some/root-relative/directory`.

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ endfunction
 Add this to your configuration:
 ```vim
 function! SideSearchRestrictedAndRelative(query, ...) abort
-  let l:subdir = get(a:, 1, '.')
-  call SideSearch(shellescape(a:query, 1), '/' . l:subdir)
+  let l:subdir = get(a:, 1, '')
+  let l:subdir = (l:subdir == '' ? '' : '/') . l:subdir
+  call SideSearch(shellescape(a:query, 1), l:subdir)
 endfunction
 command! -complete=file -nargs=+ SideSearchRestrictedAndRelative call SideSearchRestrictedAndRelative(<f-args>)
 ```

--- a/plugin/side-search.vim
+++ b/plugin/side-search.vim
@@ -187,7 +187,7 @@ endfunction
 " This will name the buffer the search term so it's easier to identify.
 " After opening the search results, the cursor should remain in it's
 " original position.
-function! SideSearch(args) abort
+function! SideSearch(args, ...) abort
   call s:defaults()
 
   let found = SideSearchWinnr()
@@ -204,16 +204,10 @@ function! SideSearch(args) abort
 
   " determine root directory
   let l:cwd = s:guessProjectRoot()
-  let l:subdirIndex = strridx(a:args, ' ')
-  if l:subdirIndex > -1
-    let l:args = strpart(a:args, 0, l:subdirIndex)
-    let l:subdir = '/' . strpart(a:args, l:subdirIndex + 1)
-  else
-    let l:args = a:args
-    let l:subdir = ''
-  endif
+  " take the relative subdirectory, if present
+  let l:subdir = get(a:, 1, '')
   " execute showing summary of stuff read (without silent)
-  let b:cmd = g:side_search_prg . ' ' . l:args . ' ' . l:cwd . l:subdir
+  let b:cmd = g:side_search_prg . ' ' . a:args . ' ' . l:cwd . l:subdir
   " Thanks: https://github.com/rking/ag.vim/blob/master/autoload/ag.vim#L154
   let query = matchstr(a:args, "\\v(-)\@<!(\<)\@<=\\w+|['\"]\\zs.{-}\\ze['\"]")
   let b:escaped_query = shellescape(query)

--- a/plugin/side-search.vim
+++ b/plugin/side-search.vim
@@ -204,8 +204,16 @@ function! SideSearch(args) abort
 
   " determine root directory
   let l:cwd = s:guessProjectRoot()
+  let l:subdirIndex = strridx(a:args, ' ')
+  if l:subdirIndex > -1
+    let l:args = strpart(a:args, 0, l:subdirIndex)
+    let l:subdir = '/' . strpart(a:args, l:subdirIndex + 1)
+  else
+    let l:args = a:args
+    let l:subdir = ''
+  endif
   " execute showing summary of stuff read (without silent)
-  let b:cmd = g:side_search_prg . ' ' . a:args . ' ' . l:cwd
+  let b:cmd = g:side_search_prg . ' ' . l:args . ' ' . l:cwd . l:subdir
   " Thanks: https://github.com/rking/ag.vim/blob/master/autoload/ag.vim#L154
   let query = matchstr(a:args, "\\v(-)\@<!(\<)\@<=\\w+|['\"]\\zs.{-}\\ze['\"]")
   let b:escaped_query = shellescape(query)


### PR DESCRIPTION
Motivation: missing `:SideSearch` ability to select a root-relative subdirectory to be searched in.

This PR:
- satisfies the motivation by allowing to implement `SideSearchRestrictedAndRelative` command/function (see below) and then do `:SideSearchRestrictedAndRelative some\ query some/root-relative/directory` (or `:SS some\ query some/root-relative/directory`)
- does not make breaking changes to the `SideSearch` command/function API

Then to use this possibility - local user config would contain:
```vim
function! SideSearchRestrictedAndRelative(query, ...) abort
  let l:subdir = get(a:, 1, '')
  let l:subdir = (l:subdir == '' ? '' : '/') . l:subdir
  call SideSearch(shellescape(a:query, 1), l:subdir)
endfunction
command! -complete=file -nargs=+ SideSearchRestrictedAndRelative call SideSearchRestrictedAndRelative(<f-args>)
```
Having these (possibly with better naming) as part of `side-search.vim`, not user config, may also be a good idea. If you agree, then there would be less additions to README.

In my config I also have the command abbreviation setup: `cabbrev SS SideSearchRestrictedAndRelative`