### PR TITLE
SideSearch(): if cmd is called with a path at the end, convert it to absolute path

### DIFF
--- a/plugin/side-search.vim
+++ b/plugin/side-search.vim
@@ -203,18 +203,14 @@ function! SideSearch(term, ...) abort
   call s:append_guide()
 
   let b:escaped = shellescape(a:term)
-  let b:cmd = g:side_search_prg . ' ' . b:escaped . ' ' . join(a:000[0:-2], ' ')
+  let b:cmd = g:side_search_prg . ' ' . b:escaped
 
   " Guess the directory if value path is not provided as last argument
   if len(a:000) == 0 || isdirectory(a:000[-1]) == 0
-     " guess the directory
     let l:cwd = s:guessProjectRoot()
-    if len(a:000) != 0
-      let b:cmd = b:cmd . ' ' . a:000[-1]
-    endif
-    let b:cmd = b:cmd . ' ' . fnamemodify(l:cwd, ':p')
+    let b:cmd = b:cmd . ' ' . join(a:000, ' ') . ' ' . fnamemodify(l:cwd, ':p')
   else
-    let b:cmd = b:cmd . ' ' . fnamemodify(a:000[-1], ':p')
+    let b:cmd = b:cmd . ' ' . join(a:000[0:-2], ' ') . ' ' . fnamemodify(a:000[-1], ':p')
   endif
 
   " echom 'a:term => ' . a:term

--- a/plugin/side-search.vim
+++ b/plugin/side-search.vim
@@ -203,13 +203,18 @@ function! SideSearch(term, ...) abort
   call s:append_guide()
 
   let b:escaped = shellescape(a:term)
-  let b:cmd = g:side_search_prg . ' ' . b:escaped . ' ' . join(a:000, ' ')
+  let b:cmd = g:side_search_prg . ' ' . b:escaped . ' ' . join(a:000[0:-2], ' ')
 
   " Guess the directory if value path is not provided as last argument
   if len(a:000) == 0 || isdirectory(a:000[-1]) == 0
      " guess the directory
     let l:cwd = s:guessProjectRoot()
-    let b:cmd = b:cmd . l:cwd
+    if len(a:000) != 0
+      let b:cmd = b:cmd . ' ' . a:000[-1]
+    endif
+    let b:cmd = b:cmd . ' ' . fnamemodify(l:cwd, ':p')
+  else
+    let b:cmd = b:cmd . ' ' . fnamemodify(a:000[-1], ':p')
   endif
 
   " echom 'a:term => ' . a:term


### PR DESCRIPTION
This fixes use case, when for example user specifies a relative path as the last argument to `:SideSearch` and then navigates from one file to another while his Vim config changes current Vim dir on every file/buffer opening/selection, for example with this config:
```vim
set autochdir
autocmd BufEnter * lcd %:p:h
```

Sorry for not noticing this in #16 